### PR TITLE
feat(smart-camera/core): record before it detects people

### DIFF
--- a/raspberrypi_central/core/app/alarm/communication/camera_video.py
+++ b/raspberrypi_central/core/app/alarm/communication/camera_video.py
@@ -1,0 +1,101 @@
+import re
+import os
+from os import path
+import logging
+
+from alarm.business import in_motion
+import alarm.utils.video_processing as video_processing
+import notification.tasks as notification
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CameraVideo:
+    REMOTE_VIDEO_FOLDER = '/var/lib/camera/media/'
+    RAW_EXT = '.h264'
+
+    def __init__(self, videos_folder: str, device_id: str):
+        self._videos_folder = videos_folder
+        self._device_id = device_id
+
+    def _local_video_path(self, filename: str) -> str:
+        """Get the local absolute path of filename.
+
+        Parameters
+        ----------
+        filename : str
+
+        Returns
+        -------
+        str
+        """
+        return path.join(self._videos_folder, filename)
+
+    @staticmethod
+    def _remote_video_path(filename: str) -> str:
+        """Get the remove absolute path of filename.
+
+        Parameters
+        ----------
+        filename : str
+
+        Returns
+        -------
+        str
+        """
+        return path.join(CameraVideo.REMOTE_VIDEO_FOLDER, filename)
+
+    @staticmethod
+    def _raw_video_file(name: str) -> str:
+        return f'{name}{CameraVideo.RAW_EXT}'
+
+    @staticmethod
+    def _get_split_number(video_ref: str) -> int:
+        split_number_pattern = r"(?P<split_number>[0-9]+$)"
+        split_number_re = re.search(split_number_pattern, video_ref)
+        if split_number_re is None:
+            raise ValueError(f'Wrong video_ref format: {video_ref}.')
+
+        split_number = split_number_re.group()
+        return int(split_number)
+
+    def camera_video(self, device_id: str, video_ref: str) -> None:
+        is_same_device = True if self._device_id == device_id else False
+
+        raw_video_file = self._local_video_path(self._raw_video_file(video_ref))
+        output_video_file = self._local_video_path(f'{video_ref}.mp4')
+
+        split_number = self._get_split_number(video_ref)
+
+        # need to download raw file from remote.
+        if not is_same_device:
+            remote_raw_video_file = self._remote_video_path(self._raw_video_file(video_ref))
+            video_processing.retrieve_video_remotely(remote_raw_video_file, raw_video_file, device_id)
+
+        # first split, merge before video and received video.
+        if split_number == 0:
+            video_ref_before_motion = f'{video_ref}-before'
+            raw_video_file_before_motion = self._local_video_path(f'{video_ref_before_motion}.h264')
+            raw_merged_video_file = self._local_video_path(f'{video_ref}-merged.h264')
+
+            # need to download the "-before" video.
+            if not is_same_device:
+                remote_raw_video_file_before_motion = self._remote_video_path(f'{video_ref_before_motion}.h264')
+                video_processing.retrieve_video_remotely(self._remote_video_path(remote_raw_video_file_before_motion), raw_video_file_before_motion, device_id)
+
+            video_processing.merge_videos([raw_video_file_before_motion, raw_video_file], raw_merged_video_file)
+
+            video_processing.h264_to_mp4(raw_merged_video_file, output_video_file)
+        else:
+            video_processing.h264_to_mp4(raw_video_file, output_video_file)
+
+        LOGGER.info(f'video to mp4 ok - {output_video_file}')
+
+        notification.send_video(output_video_file)
+        in_motion.save_camera_video(video_ref)
+
+def camera_video_factory():
+    videos_folder = os.environ['VIDEO_FOLDER']
+    device_id = os.environ['DEVICE_ID']
+
+    return CameraVideo(videos_folder, device_id)

--- a/raspberrypi_central/core/app/alarm/communication/camera_video.py
+++ b/raspberrypi_central/core/app/alarm/communication/camera_video.py
@@ -33,7 +33,7 @@ class CameraVideo:
 
     @staticmethod
     def _remote_video_path(filename: str) -> str:
-        """Get the remove absolute path of filename.
+        """Get the remote absolute path of filename.
 
         Parameters
         ----------
@@ -60,7 +60,7 @@ class CameraVideo:
         return int(split_number)
 
     def camera_video(self, device_id: str, video_ref: str) -> None:
-        is_same_device = True if self._device_id == device_id else False
+        is_same_device = self._device_id == device_id
 
         raw_video_file = self._local_video_path(self._raw_video_file(video_ref))
         output_video_file = self._local_video_path(f'{video_ref}.mp4')

--- a/raspberrypi_central/core/app/alarm/mqtt.py
+++ b/raspberrypi_central/core/app/alarm/mqtt.py
@@ -69,7 +69,9 @@ def on_motion_video(message: MqttMessage) -> None:
     if data['device_id'] == DEVICE_ID:
         data['is_same_device'] = True
 
-    tasks.camera_motion_video.apply_async(kwargs=data)
+    # The system has some latency to save the video,
+    # so we add a little countdown so the video will more likely be available after x seconds.
+    tasks.camera_motion_video.apply_async(kwargs=data, countdown=3)
 
 def on_motion_picture(message: MqttMessage):
     topic = split_camera_topic(message.topic, True)

--- a/raspberrypi_central/core/app/alarm/mqtt.py
+++ b/raspberrypi_central/core/app/alarm/mqtt.py
@@ -63,11 +63,7 @@ def on_motion_video(message: MqttMessage) -> None:
     data = {
         'device_id': topic['device_id'],
         'video_ref': topic['event_ref'],
-        'is_same_device': False
     }
-
-    if data['device_id'] == DEVICE_ID:
-        data['is_same_device'] = True
 
     # The system has some latency to save the video,
     # so we add a little countdown so the video will more likely be available after x seconds.

--- a/raspberrypi_central/core/app/alarm/tasks.py
+++ b/raspberrypi_central/core/app/alarm/tasks.py
@@ -54,10 +54,6 @@ def h264_to_mp4(input_path: str, output_path: str):
     retry_kwargs={'max_retries': 5},
     default_retry_delay=3)
 def process_video(raw_video_file: str, output_path: str) -> None:
-    # videos = os.environ['VIDEO_FOLDER']
-    #
-    # raw_video_path = os.path.join(videos, raw_video_file)
-
     if not Path(raw_video_file).is_file():
         raise FileNotFoundError(f'{raw_video_file} does not exist.')
 
@@ -66,12 +62,6 @@ def process_video(raw_video_file: str, output_path: str) -> None:
 
     # we don't need raw h264 anymore.
     os.remove(raw_video_file)
-
-    # kwargs = {
-    #     'video_path': output_path
-    # }
-    #
-    # send_video.apply_async(kwargs=kwargs)
 
 
 @shared_task(

--- a/raspberrypi_central/core/app/alarm/tasks.py
+++ b/raspberrypi_central/core/app/alarm/tasks.py
@@ -1,22 +1,14 @@
 import os
-from os import path
 import logging
-import re
-from pathlib import Path
-from typing import Optional, Tuple, List
+from typing import Tuple
 
-from celery import shared_task, group, signature
-
-from notification.consts import SeverityChoice
-from notification.tasks import send_video, create_and_send_notification
+from celery import shared_task
 from utils.date import is_time_newer_than
-from .business import in_motion
 from .business.alarm_change_status import AlarmScheduleChangeStatus
 from alarm.communication.camera_motion import camera_motion_factory
 from alarm.models import AlarmStatus, Ping
 import alarm.notifications as notifications
 from .communication.camera_video import camera_video_factory
-from .utils.video_processing import h264_to_mp4
 
 LOGGER = logging.getLogger(__name__)
 

--- a/raspberrypi_central/core/app/alarm/tasks.py
+++ b/raspberrypi_central/core/app/alarm/tasks.py
@@ -1,4 +1,5 @@
 import os
+from os import path
 import logging
 import re
 from pathlib import Path
@@ -14,86 +15,10 @@ from .business.alarm_change_status import AlarmScheduleChangeStatus
 from alarm.communication.camera_motion import camera_motion_factory
 from alarm.models import AlarmStatus, Ping
 import alarm.notifications as notifications
+from .communication.camera_video import camera_video_factory
+from .utils.video_processing import h264_to_mp4
 
 LOGGER = logging.getLogger(__name__)
-
-def h264_to_mp4(input_path: str, output_path: str):
-    """Convert raw h264 'input_path' to mp4 in 'output_path' or in 'input_path' with .mp4 extension.
-
-    Parameters
-    ----------
-    input_path : str
-    output_path : str, optional
-
-    Raises
-    ------
-    Exception
-        If underlying MP4Box command is not exited normally,
-            probably something went wrong and the file is not converted.
-
-    Returns
-    -------
-    str
-        The path to the newly (converted) video.
-    """
-
-    # MP4Box redirect everything to stderr (even if no error).
-    # so we redirect stderr to stdout to /dev/null
-    # so nothing is printed to avoid logs pollution.
-    # if an error happens, we catch it thanks to the result.
-    command = f'MP4Box -add {input_path} {output_path} > /dev/null 2>&1'
-
-    # warning: call could be problematic in Celery tasks.
-    result = os.system(command)
-    if result != 0:
-        raise Exception(f'{command} did not exited successfully.')
-
-
-@shared_task(
-    autoretry_for=(Exception,),
-    retry_kwargs={'max_retries': 5},
-    default_retry_delay=3)
-def process_video(raw_video_file: str, output_path: str) -> None:
-    if not Path(raw_video_file).is_file():
-        raise FileNotFoundError(f'{raw_video_file} does not exist.')
-
-    h264_to_mp4(raw_video_file, output_path)
-    LOGGER.info(f'video to mp4 ok - {output_path}')
-
-    # we don't need raw h264 anymore.
-    os.remove(raw_video_file)
-
-
-@shared_task(
-    autoretry_for=(Exception,),
-    retry_kwargs={'max_retries': 5},
-    default_retry_delay=3)
-def retrieve_and_process_video(device_id: str, video_file: str):
-    remote_path = f'/var/lib/camera/media/{video_file}'
-    dest_path = os.environ['VIDEO_FOLDER']
-
-    video_dest_path = os.path.join(dest_path, video_file)
-
-    command = f"rsync -avt --remove-source-files pi@{device_id}:{remote_path} {video_dest_path}"
-    os.system(command)
-
-    process_video(video_dest_path)
-
-
-@shared_task()
-def merge_videos(videos_path: List[str], output_video_path: str) -> None:
-    if len(videos_path) < 1:
-        return None
-
-    command_file = f'-add {videos_path[0]}'
-    for video_path in videos_path[1:]:
-        command_file += f' -cat {video_path}'
-
-    command = f'MP4Box {command_file} {output_video_path} > /dev/null 2>&1'
-
-    result = os.system(command)
-    if result != 0:
-        raise Exception(f'{command} did not exited successfully.')
 
 @shared_task(name="security.camera_motion_picture")
 def camera_motion_picture(device_id: str, picture_path: str, event_ref: str, status: bool):
@@ -104,83 +29,8 @@ def camera_motion_detected(device_id: str, seen_in: dict, event_ref: str, status
     camera_motion_factory().camera_motion_detected(device_id, seen_in, event_ref, status)
 
 @shared_task(name='security.camera_motion_video')
-def camera_motion_video(device_id: str, video_ref: str, is_same_device: bool = False) -> None:
-    """Save camera video reference to the database. It adds/extracts useful information.
-
-     Parameters
-     ----------
-     device_id : str
-        The device_id that sent the `video_ref`.
-
-     video_ref : str
-         A string that represents a video_ref, ex: '49efa0b4-2003-44e4-920c-4eb0e6eea358-1'
-             composed by two parts: the first one, the `event_ref` and the `record_number`.
-
-     is_same_device : bool
-        Either or not the `device_id` (so the device) is the same as the one that executes the function.
-
-     Returns
-     -------
-     None
-     """
-
-
-    """
-    doing:
-    if video ref is ending by "-0" we have to:
-    - process the f'{video_ref}-before.h264' and the "-0", then merge them then send the notification.
-    (process_video() & process_video()).then(merge).then(send)
-    """
-
-    videos_folder = os.environ['VIDEO_FOLDER']
-
-    raw_video_file = os.path.join(videos_folder, f'{video_ref}.h264')
-    video_file = os.path.join(videos_folder, f'{video_ref}.mp4')
-
-    split_number_pattern = r"(?P<split_number>[0-9]+$)"
-    split_number_re = re.search(split_number_pattern, video_ref)
-    if split_number_re is None:
-        raise ValueError(f'Wrong video_ref format: {video_ref}.')
-
-    split_number = split_number_re.group()
-
-    # first split, merge before video and splited video.
-    if split_number == '0':
-        print('first split, will merge before and current split video')
-
-        video_ref_before_motion = f'{video_ref}-before'
-        raw_video_file_before_motion = os.path.join(videos_folder, f'{video_ref_before_motion}.h264')
-        raw_merged_video_file = os.path.join(videos_folder, f'{video_ref}-merged.h264')
-
-        # job = group([
-        #     process_video.s(raw_video_file),
-        #     process_video.s(f'{video_file_before_motion}.h264')
-        # ])
-        # result = job.apply_async()
-        # if not result.successful():
-        #     raise Exception('not all subtasks were successful.')
-
-        # process_video(raw_video_file, video_file)
-        # process_video(f'{video_file_before_motion}.h264', f'{video_file_before_motion}.mp4')
-
-        # output_path = f'{video_ref}.mp4'
-
-        # -before -0 -> merged in raw_merged_video_file
-        merge_videos([raw_video_file_before_motion, raw_video_file], raw_merged_video_file)
-
-        # raw_merged_video_file to video_file mp4
-        process_video(raw_merged_video_file, video_file)
-        send_video(video_path=video_file)
-
-    else:
-        if is_same_device:
-            # The system has some latency to save the video,
-            # so we add a little countdown so the video will more likely be available after x seconds.
-            process_video.apply_async(kwargs={'raw_video_file': raw_video_file})
-        else:
-            retrieve_and_process_video.apply_async(kwargs={'raw_video_file': raw_video_file, 'device_id': device_id})
-
-    in_motion.save_camera_video(video_ref)
+def camera_motion_video(device_id: str, video_ref: str) -> None:
+    camera_video_factory().camera_video(device_id, video_ref)
 
 @shared_task(name="alarm.set_alarm_off")
 def set_alarm_off(alarm_status_uui):

--- a/raspberrypi_central/core/app/alarm/tests/test_camera_video.py
+++ b/raspberrypi_central/core/app/alarm/tests/test_camera_video.py
@@ -1,0 +1,111 @@
+from unittest.mock import patch, MagicMock, call
+
+from django.test import TestCase
+from alarm.communication.camera_video import CameraVideo
+
+
+class CameraVideoTestCase(TestCase):
+    def setUp(self) -> None:
+        self.video_folder = '/usr/random'
+        self.device_id = 'some_device_id'
+        self.another_device_id = 'another_device_id'
+        self.video_ref = '1be409e1-7625-490a-9a8a-428ba4b8e88c-1'
+        self.camera_video = CameraVideo(self.video_folder, self.device_id)
+        self._setup_video_ref_var()
+
+    def _setup_video_ref_var(self):
+        self.output_video = f'{self.video_folder}/{self.video_ref}.mp4'
+        self.raw_video = f'{self.video_folder}/{self.video_ref}.h264'
+
+        self.before_raw_video = f'{self.video_folder}/{self.video_ref}-before.h264'
+        self.before_raw_video_merged = f'{self.video_folder}/{self.video_ref}-merged.h264'
+
+    @patch('alarm.utils.video_processing.retrieve_video_remotely')
+    @patch('alarm.utils.video_processing.merge_videos')
+    @patch('notification.tasks.send_video')
+    @patch('alarm.utils.video_processing.h264_to_mp4')
+    def test_camera_video_self_device(self, h264_to_mp4: MagicMock, send_video: MagicMock, merge_videos: MagicMock, retrieve_video_remotely: MagicMock):
+        self.camera_video.camera_video(self.device_id, self.video_ref)
+
+        h264_to_mp4.assert_called_once_with(
+            self.raw_video,
+            self.output_video
+        )
+
+        send_video.assert_called_once_with(self.output_video)
+
+        merge_videos.assert_not_called()
+        retrieve_video_remotely.assert_not_called()
+
+    @patch('alarm.utils.video_processing.retrieve_video_remotely')
+    @patch('alarm.utils.video_processing.merge_videos')
+    @patch('notification.tasks.send_video')
+    @patch('alarm.utils.video_processing.h264_to_mp4')
+    def test_camera_video_remote(self, h264_to_mp4: MagicMock, send_video: MagicMock, merge_videos: MagicMock, retrieve_video_remotely: MagicMock):
+        self.camera_video.camera_video(self.another_device_id, self.video_ref)
+
+        h264_to_mp4.assert_called_once_with(
+            self.raw_video,
+            self.output_video
+        )
+
+        send_video.assert_called_once_with(self.output_video)
+
+        merge_videos.assert_not_called()
+
+        retrieve_video_remotely.assert_called_once_with(
+            f'{CameraVideo.REMOTE_VIDEO_FOLDER}{self.video_ref}.h264',
+            self.raw_video,
+            self.another_device_id
+        )
+
+
+    @patch('alarm.utils.video_processing.retrieve_video_remotely')
+    @patch('alarm.utils.video_processing.merge_videos')
+    @patch('notification.tasks.send_video')
+    @patch('alarm.utils.video_processing.h264_to_mp4')
+    def test_camera_first_video_self_device(self, h264_to_mp4: MagicMock, send_video: MagicMock, merge_videos: MagicMock, retrieve_video_remotely: MagicMock):
+        self.video_ref = '1be409e1-7625-490a-9a8a-428ba4b8e88c-0'
+        self._setup_video_ref_var()
+
+        self.camera_video.camera_video(self.device_id, self.video_ref)
+
+        merge_videos.assert_called_once_with([self.before_raw_video, self.raw_video], self.before_raw_video_merged)
+
+        h264_to_mp4.assert_called_once_with(
+            self.before_raw_video_merged,
+            self.output_video
+        )
+
+        send_video.assert_called_once_with(self.output_video)
+        retrieve_video_remotely.assert_not_called()
+
+    @patch('alarm.utils.video_processing.retrieve_video_remotely')
+    @patch('alarm.utils.video_processing.merge_videos')
+    @patch('notification.tasks.send_video')
+    @patch('alarm.utils.video_processing.h264_to_mp4')
+    def test_camera_first_video_remote(self, h264_to_mp4: MagicMock, send_video: MagicMock, merge_videos: MagicMock, retrieve_video_remotely: MagicMock):
+        self.video_ref = '1be409e1-7625-490a-9a8a-428ba4b8e88c-0'
+        self._setup_video_ref_var()
+
+        self.camera_video.camera_video(self.another_device_id, self.video_ref)
+
+        retrieve_video_remotely.assert_has_calls([
+            call(
+                f'{CameraVideo.REMOTE_VIDEO_FOLDER}{self.video_ref}.h264',
+                self.raw_video,
+                self.another_device_id),
+            call(
+                f'{CameraVideo.REMOTE_VIDEO_FOLDER}{self.video_ref}-before.h264',
+                self.before_raw_video,
+                self.another_device_id)
+        ])
+
+        merge_videos.assert_called_once_with([self.before_raw_video, self.raw_video], self.before_raw_video_merged)
+
+        h264_to_mp4.assert_called_once_with(
+            self.before_raw_video_merged,
+            self.output_video
+        )
+
+        send_video.assert_called_once_with(self.output_video)

--- a/raspberrypi_central/core/app/alarm/utils/video_processing.py
+++ b/raspberrypi_central/core/app/alarm/utils/video_processing.py
@@ -1,0 +1,79 @@
+import os
+from typing import List
+from pathlib import Path
+
+
+def retrieve_video_remotely(remote_raw_video_file: str, local_dest: str, device_id: str) -> None:
+    """
+
+    Parameters
+    ----------
+    remote_raw_video_file : str
+    local_dest : str
+        Output folder of rsync. Every file that will be sync will go to this folder.
+    device_id : str
+
+    Returns
+    -------
+    None
+    """
+
+    # --remove-source-files removes file from the source
+    # used to clean the file from the remote because it is not necessary to keep it once it has been downloaded.
+    command = f"rsync -avt --remove-source-files pi@{device_id}:{remote_raw_video_file} {local_dest}"
+    os.system(command)
+
+
+def merge_videos(videos_path: List[str], output_video_path: str) -> None:
+    if len(videos_path) < 1:
+        return None
+
+    command_file = f'-add {videos_path[0]}'
+    for video_path in videos_path[1:]:
+        command_file += f' -cat {video_path}'
+
+    command = f'MP4Box {command_file} {output_video_path} > /dev/null 2>&1'
+
+    result = os.system(command)
+    if result != 0:
+        raise Exception(f'{command} did not exited successfully.')
+
+
+def h264_to_mp4(input_path: str, output_path: str, delete_input: bool = False) -> None:
+    """Convert raw h264 'input_path' to mp4 in 'output_path' or in 'input_path' with .mp4 extension.
+
+    Parameters
+    ----------
+    input_path : str
+    output_path : str
+    delete_input : bool
+        Either or not the input should be deleted after processing.
+
+    Raises
+    ------
+    Exception
+        If underlying MP4Box command is not exited normally,
+            probably something went wrong and the file is not converted.
+
+    Returns
+    -------
+    str
+        The path to the newly (converted) video.
+    """
+
+    # MP4Box redirect everything to stderr (even if no error).
+    # so we redirect stderr to stdout to /dev/null
+    # so nothing is printed to avoid logs pollution.
+    # if an error happens, we catch it thanks to the result.
+    if not Path(input_path).is_file():
+        raise FileNotFoundError(f'{input_path} does not exist.')
+
+    command = f'MP4Box -add {input_path} {output_path} > /dev/null 2>&1'
+
+    # warning: call could be problematic in Celery tasks.
+    result = os.system(command)
+    if result != 0:
+        raise Exception(f'{command} did not exited successfully.')
+
+    if delete_input is True:
+        os.remove(input_path)

--- a/raspberrypi_central/dumb_install.sh
+++ b/raspberrypi_central/dumb_install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Script used to setup raspberry pi zero for dumb camera.
-
+sudo apt update && sudo apt upgrade -y
 sudo apt install -y git python3-pip
 
 # enable the pi camera. Warning: need reboot (done at the end).

--- a/raspberrypi_central/smart-camera/app/camera/pivideostream.py
+++ b/raspberrypi_central/smart-camera/app/camera/pivideostream.py
@@ -59,7 +59,7 @@ class PiVideoStream:
             # @todo: add self._before_stream to the new recording, at the beginning.
 
             # Write the x seconds "before" motion to disk as well
-            self._ring_buffer.copy_to(os.path.join(PiVideoStream.BASE_VIDEO_PATH, f'{video_ref}-before.h264'), seconds=10)
+            self._ring_buffer.copy_to(os.path.join(PiVideoStream.BASE_VIDEO_PATH, f'{video_ref}-before.h264'), seconds=PiVideoStream.SECONDS_BUFFER)
             self._ring_buffer.clear()
 
             # split the recording to record frames just after the system detects people.

--- a/raspberrypi_central/smart-camera/app/camera/pivideostream.py
+++ b/raspberrypi_central/smart-camera/app/camera/pivideostream.py
@@ -56,8 +56,6 @@ class PiVideoStream:
             LOGGER.info(f'start recording video_ref={video_ref}')
             self._record = True
 
-            # @todo: add self._before_stream to the new recording, at the beginning.
-
             # Write the x seconds "before" motion to disk as well
             self._ring_buffer.copy_to(os.path.join(PiVideoStream.BASE_VIDEO_PATH, f'{video_ref}-before.h264'), seconds=PiVideoStream.SECONDS_BUFFER)
             self._ring_buffer.clear()

--- a/raspberrypi_central/smart-camera/app/dumb_camera.py
+++ b/raspberrypi_central/smart-camera/app/dumb_camera.py
@@ -33,7 +33,7 @@ try:
 
     camera_mqtt_client = get_mqtt(f"{device_id}-dumb-camera-manager")
 
-    camera_manager = ThreadManager(RunDumbCameraFrameProducer())
+    camera_manager = RunDumbCameraFrameProducer()
 
     MqttManageRunnable(device_id, 'camera', camera_mqtt_client, camera_manager, status_json=True)
 

--- a/raspberrypi_central/smart-camera/app/entrypoint_dumb_camera.sh
+++ b/raspberrypi_central/smart-camera/app/entrypoint_dumb_camera.sh
@@ -5,4 +5,4 @@
 # it's natively done by shell.
 
 export MEDIA_FOLDER=/var/lib/camera/media
-set -a; source ../.env; source ~/.device; set +a && pip3 install --user --requirement ./requirements.txt && python3 dumb_camera.py
+set -a; source ../.env; source ~/.device; set +a && python3 -m pip install --user --requirement ./requirements.txt && python3 dumb_camera.py

--- a/raspberrypi_central/smart-camera/app/service_manager/run_camera_frame_producer.py
+++ b/raspberrypi_central/smart-camera/app/service_manager/run_camera_frame_producer.py
@@ -62,8 +62,7 @@ class ManageRecord:
 
 
 class FrameProducer:
-    def __init__(self, stream_event: mp.Event, process_event: mp.Event, high_fps_queue: mp.Queue):
-        self._high_fps_queue = high_fps_queue
+    def __init__(self, stream_event: mp.Event, process_event: mp.Event):
         self._stream_event = stream_event
         self._process_event = process_event
 
@@ -82,15 +81,6 @@ class FrameProducer:
 
         # @rate_limited(max_per_second=0.5, thread_safe=False, block=True)
         def process_frame(frame: BytesIO):
-            try:
-                high_fps = self._high_fps_queue.get(block=False)
-            except Empty:
-                # it does not need to change fps
-                high_fps = None
-
-            if high_fps is not None:
-                stream.high_fps() if high_fps is True else stream.low_fps()
-
             camera.process_frame(frame, stream=self._stream_event.is_set(), process=self._process_event.is_set())
 
         stream.process_frame = process_frame
@@ -100,11 +90,10 @@ class FrameProducer:
 
 class RunCameraFrameProducer(Runnable):
     def __init__(self):
-        self._high_fps_queue = mp.Queue()
         self._stream_event = mp.Event()
         self._process_event = mp.Event()
 
-        self._frame_producer = FrameProducer(self._stream_event, self._process_event, self._high_fps_queue)
+        self._frame_producer = FrameProducer(self._stream_event, self._process_event)
         self._process = None
 
     def run(self, device_id: str, status: bool, data=None) -> None:
@@ -117,11 +106,9 @@ class RunCameraFrameProducer(Runnable):
         if data:
             if 'stream' in data:
                 if data['stream'] is True:
-                    self._high_fps_queue.put(True)
                     self._stream_event.set()
                 elif data['stream'] is False:
                     self._stream_event.clear()
-                    self._high_fps_queue.put(False)
 
             if 'to_analyze' in data:
                 if data['to_analyze'] is True:

--- a/raspberrypi_central/smart-camera/app/service_manager/run_dumb_camera_frame_producer.py
+++ b/raspberrypi_central/smart-camera/app/service_manager/run_dumb_camera_frame_producer.py
@@ -9,9 +9,9 @@ DEVICE_ID = os.environ['DEVICE_ID']
 
 class RunDumbCameraFrameProducer(RunCameraFrameProducer):
 
-    def run(self) -> None:
+    def run(self, device_id: str, status: bool, data=None) -> None:
         try:
-            super().run()
+            super().run(device_id, status, data)
         except BaseException as e:
             tags = {'device': DEVICE_ID}
             logger.error(traceback.format_exc(),


### PR DESCRIPTION
## Feature
- closes #167 


The camera records constantly in a circular buffer which contains 20 seconds of record.

It means the system records when somebody comes in the camera vision which could be useful, for example you can see how/where the burglar break in your place.

It removes features to set high and low fps to Picamera because it needs to stream at high (25) fps all the time, otherwise the "before motion" would be at low (1) fps which would have make it useless.

## Technically
It uses a circular buffer provided by PiCamera library. When a motion is detected it writes the 20s buffer in disk. Then when the `core` app receives the message that the first video is available, it merges the "before motion" video with the first video. And voilà!

## Issues
For the first video record it works, then it does not work: it does not save files on disk...
Fix: buffer.copy_to(seconds=10) but my buffer was declared with seconds=20. I use a variable to avoid this issue.