### PR TITLE
docker(core): change core image

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -57,7 +57,7 @@ build-docker:
 
 .PHONY: docker-build-release
 docker-build-release:
-	docker buildx build --build-arg USER_ID=$(user) --build-arg GROUP_ID=$(group) --push --platform linux/arm/v7,linux/amd64 --tag mxmaxime/core:$(version) ./app
+	docker buildx build --build-arg USER_ID=$(user) --build-arg GROUP_ID=$(group) --push --platform linux/arm/v7,linux/amd64 --tag bobbyhome/core:$(version) ./app
 
 .PHONY: test
 test:

--- a/core/Makefile
+++ b/core/Makefile
@@ -53,7 +53,7 @@ mqtt-services:
 
 .PHONY: build-docker
 build-docker:
-	$(dc) build
+	DOCKER_BUILDKIT=1 $(dc) build $(services)
 
 .PHONY: docker-build-release
 docker-build-release:

--- a/core/app/Dockerfile
+++ b/core/app/Dockerfile
@@ -1,18 +1,42 @@
 FROM python:3.9.4-slim-buster as base
 
-FROM base as builder
-# upgrade python with root user
-RUN pip install --upgrade pip
+# do not use slim image to build
+# it misses a lot of necessary packages to build pip dependencies (gcc for example).
+FROM python:3.9.4 as builder
 
-# install dependencies
-COPY requirements.txt /tmp/
+# libpq-dev is used for psycopg2-binary, see: https://stackoverflow.com/a/12037133
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+    build-essential libssl-dev libffi-dev \
+    python3-dev \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# install Rust to have a Rust compiler needed by the python cryptography package.
+# use the recommanded way to install Rust in order to ensure we have a recent version.
+# more information: https://cryptography.io/en/latest/installation.html
+# for arch amd64 not issue because pip does not build cryptography
+# but for linux/arm/v7 it does.
+RUN curl --proto '=https' --tlsv1.2 -sSf -y https://sh.rustup.rs | sh
+RUN pip install --upgrade pip
 
 # add pip dependencies folder to PATH
 ENV PATH="/root/.local/bin:${PATH}"
+# add rust to PATH
+ENV PATH="/root/.cargo/bin:${PATH}"
 
-# thanks to --user, pip will install everything in user directory ~/.local/bin/
-RUN pip install --user --requirement /tmp/requirements.txt
+# for pip cryptography (3.4.5) package.
+# was suggested in the build failure message.
+# see: https://github.com/docker/compose/issues/8105#issuecomment-775879420
+# sadly even with rust downloaded it does not find the Rust compiler,
+# and I do not get the time to invesgitate any further the issue.
+ENV CRYPTOGRAPHY_DONT_BUILD_RUST 1
 
+COPY requirements.txt /tmp/
+RUN --mount=type=cache,mode=0755,target=/root/.cache \
+  pip install --user --requirement /tmp/requirements.txt
+
+# final image
 FROM base
 ARG USER_ID
 ARG GROUP_ID
@@ -31,7 +55,6 @@ ENV PATH="/home/house/.local/bin:${PATH}"
 # netcat is not required for alpine images, but debian based yes.
 # otherwise "nc" command not found.
 # gettext is used by django to extract texts to translate: https://docs.djangoproject.com/en/3.1/topics/i18n/translation/#message-files
-# libpq-dev is used for psycopg2-binary, see: https://stackoverflow.com/a/12037133
 # only worker: gpac is used to convert PiCamera videos h264 to mp4
 # only worker: rsync is used to retrieve videos
 RUN apt-get update \
@@ -42,7 +65,7 @@ RUN apt-get update \
     netcat \
     rsync \
     && rm -rf /var/lib/apt/lists/*
-# set work directory
+
 WORKDIR /usr/src/app
 
 # don't generate *.pyc files
@@ -50,11 +73,6 @@ ENV PYTHONDONTWRITEBYTECODE 1
 
 # print to stdout without buffering
 ENV PYTHONUNBUFFERED 1
-
-# for pip cryptography (3.4.5) package.
-# was suggested in the build failure message.
-# see: https://github.com/docker/compose/issues/8105#issuecomment-775879420
-ENV CRYPTOGRAPHY_DONT_BUILD_RUST 1
 
 USER house
 

--- a/core/app/Dockerfile
+++ b/core/app/Dockerfile
@@ -54,6 +54,8 @@ ENV PATH="/home/house/.local/bin:${PATH}"
 
 # netcat is not required for alpine images, but debian based yes.
 # otherwise "nc" command not found.
+# libpq-dev is used by psycopg2
+# otherwise: "Error loading psycopg2 module: libpq.so.5: cannot open shared object file: No such file or directory"
 # gettext is used by django to extract texts to translate: https://docs.djangoproject.com/en/3.1/topics/i18n/translation/#message-files
 # only worker: gpac is used to convert PiCamera videos h264 to mp4
 # only worker: rsync is used to retrieve videos

--- a/core/app/Dockerfile
+++ b/core/app/Dockerfile
@@ -1,6 +1,19 @@
-# pull official base image
-FROM python:3.8.7
+FROM python:3.9.4-slim-buster as base
 
+FROM base as builder
+# upgrade python with root user
+RUN pip install --upgrade pip
+
+# install dependencies
+COPY requirements.txt /tmp/
+
+# add pip dependencies folder to PATH
+ENV PATH="/root/.local/bin:${PATH}"
+
+# thanks to --user, pip will install everything in user directory ~/.local/bin/
+RUN pip install --user --requirement /tmp/requirements.txt
+
+FROM base
 ARG USER_ID
 ARG GROUP_ID
 
@@ -9,6 +22,26 @@ RUN groupadd -f -g $GROUP_ID house && adduser --disabled-password --gecos '' --u
     mkdir -p /var/lib/house; \
 	chown -R house:house /var/lib/house
 
+COPY --from=builder /root/.local /home/house/.local
+RUN chown -R house:house /home/house/.local
+
+# add pip dependencies folder to PATH
+ENV PATH="/home/house/.local/bin:${PATH}"
+
+# netcat is not required for alpine images, but debian based yes.
+# otherwise "nc" command not found.
+# gettext is used by django to extract texts to translate: https://docs.djangoproject.com/en/3.1/topics/i18n/translation/#message-files
+# libpq-dev is used for psycopg2-binary, see: https://stackoverflow.com/a/12037133
+# only worker: gpac is used to convert PiCamera videos h264 to mp4
+# only worker: rsync is used to retrieve videos
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+    gettext \
+    gpac \
+    libpq-dev \
+    netcat \
+    rsync \
+    && rm -rf /var/lib/apt/lists/*
 # set work directory
 WORKDIR /usr/src/app
 
@@ -18,34 +51,12 @@ ENV PYTHONDONTWRITEBYTECODE 1
 # print to stdout without buffering
 ENV PYTHONUNBUFFERED 1
 
-# netcat is not required for alpine images, but debian based yes.
-# otherwise "nc" command not found.
-# gettext is used by django to extract texts to translate: https://docs.djangoproject.com/en/3.1/topics/i18n/translation/#message-files
-# libpq-dev is used for psycopg2-binary, see: https://stackoverflow.com/a/12037133
-# gpac is used to convert PiCamera videos h264 to mp4
-# rsync is used to retrieve videos
-RUN apt-get update \
-    && apt-get install -y libpq-dev netcat gettext gpac rsync
-
 # for pip cryptography (3.4.5) package.
 # was suggested in the build failure message.
 # see: https://github.com/docker/compose/issues/8105#issuecomment-775879420
 ENV CRYPTOGRAPHY_DONT_BUILD_RUST 1
 
-# upgrade python with root user
-RUN pip install --upgrade pip
-
-# run everything with this user
 USER house
-
-# add pip dependencies folder to PATH
-ENV PATH="/home/house/.local/bin:${PATH}"
-
-# install dependencies
-COPY requirements.txt /tmp/
-
-# thanks to --user, pip will install everything in user directory ~/.local/bin/
-RUN pip install --user --requirement /tmp/requirements.txt
 
 # copy entrypoint.sh
 COPY ./entrypoint.sh /usr/src/app/entrypoint.sh

--- a/core/docker-compose.prod.yml
+++ b/core/docker-compose.prod.yml
@@ -11,6 +11,9 @@ x-env: &env
         - .env
         - ~/.device
 
+x-coreimage: &coreimage
+    image: bobbyhome/core:0.4.1
+
 services:
     rabbit:
         logging: *loki-logging
@@ -55,25 +58,25 @@ services:
         restart: unless-stopped
 
     rabbit_worker:
-        image: mxmaxime/core:0.3.2
+        <<: *coreimage
         logging: *loki-logging
         restart: unless-stopped
         <<: *env
 
     celery_beat:
-        image: mxmaxime/core:0.3.2
+        <<: *coreimage
         logging: *loki-logging
         restart: unless-stopped
         <<: *env
 
     telegram_bot:
-        image: mxmaxime/core:0.3.2
+        <<: *coreimage
         logging: *loki-logging
         restart: unless-stopped
         <<: *env
 
     web:
-        image: mxmaxime/core:0.3.2
+        <<: *coreimage
         #        command: gunicorn hello_django.wsgi:application --bind 0.0.0.0:8000
         ports:
             - 8000:8000
@@ -82,7 +85,7 @@ services:
         restart: unless-stopped
 
     python_process_mqtt:
-        image: mxmaxime/core:0.3.2
+        <<: *coreimage
         logging: *loki-logging
         restart: unless-stopped
         <<: *env

--- a/core/docker-compose.prod.yml
+++ b/core/docker-compose.prod.yml
@@ -12,7 +12,7 @@ x-env: &env
         - ~/.device
 
 x-coreimage: &coreimage
-    image: bobbyhome/core:0.4.1
+    image: bobbyhome/core:0.4.3
 
 services:
     rabbit:

--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -28,7 +28,7 @@ services:
             - webapp_backend
 
     mqtt_broker:
-        image: eclipse-mosquitto:2.0.8
+        image: eclipse-mosquitto:2.0.10
         volumes:
             - ./config/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
             - ./config/mosquitto/passwd:/mosquitto/config/passwd


### PR DESCRIPTION
- Upgrade python 3.8.7 to 3.9.4
- Change python base image to `slim-buster`. Significantly smaller.
- Use buildkit from docker. Seems to be way quicker on my laptop. `make build-docker`, `make build-docker services=web database ...`
- Use multistage build :rocket: to decrease our final image size! Before this PR everything was done in one stage thus the final image contained unnecessary things.
- upgrade mosquitto from 2.0.8 to 2.0.10 does not change anything but fix weird docker bugs when mounting the passwd file.
- use pip caching: avoid downloading everything when we change one library.