### PR TITLE
fix(core): reset ping when it comes back #182

### DIFF
--- a/core/app/alarm/business/alarm.py
+++ b/core/app/alarm/business/alarm.py
@@ -1,6 +1,6 @@
 from alarm.models import Ping
 from devices.models import Device
-from django.db.models import Model
+from django.db.models import Model, F
 from django.utils import timezone
 
 
@@ -13,8 +13,18 @@ def is_status_exists(model_ref: Model, device_id: str, running: bool) -> bool:
 
     return False
 
+
 def register_ping(device_id: str, service_name: str) -> None:
-    Ping.objects.update_or_create(
+    _obj, created = Ping.objects.get_or_create(
         device_id=device_id, service_name=service_name,
-        defaults={'last_update': timezone.now()}
+        defaults={
+            'last_update': timezone.now(),
+            'failures': 0,
+            'consecutive_failures': 0
+        }
     )
+    
+    if not created:
+        Ping.objects.filter(device_id=device_id, service_name=service_name)\
+                .update(failures=F('consecutive_failures') + F('failures'), consecutive_failures=0)
+

--- a/core/app/alarm/tests/test_ping.py
+++ b/core/app/alarm/tests/test_ping.py
@@ -1,0 +1,30 @@
+from alarm.models import Ping
+from alarm.business.alarm import register_ping
+from django.test import TestCase
+
+
+class RegisterTestPing(TestCase):
+    def setUp(self) -> None:
+        self._device_id = 'id5'
+        self._service_name = 'service_name'
+
+    def test_register_ping_create(self):
+        register_ping(self._device_id, self._service_name)
+        pings = Ping.objects.filter(device_id=self._device_id)
+        self.assertEqual(1, len(pings))
+
+    def test_register_update(self):
+        Ping.objects.create(
+                device_id=self._device_id,
+                service_name=self._service_name,
+                consecutive_failures=2,
+        )
+        
+        register_ping(self._device_id, self._service_name)
+        pings = Ping.objects.filter(device_id=self._device_id)
+
+        self.assertEqual(1, len(pings), 'it should update ping, not create a new one')
+        ping = pings[0]
+        self.assertEqual(0, ping.consecutive_failures, 'it should reset consecutive_failures when new ping is registered')
+        self.assertEqual(2, ping.failures, 'it should add consecutive_failures to failures')
+


### PR DESCRIPTION
- fixes #182 
- :heavy_check_mark: covered by a new test scenario.

After a bit of research, I spot an issue: when the core receives a ping, it does not reset `consecutive_failures` to 0, it only registers the ping date...

Currently, when the system checks for pings, if `consecutive_failures > 3` it sends a notification because something is considered to be wrong: it means the `object_detection` service did not receive any frame for the last 3-4 minutes.

1-2 failures is considered to be ok but should not happens frequently, no check on this side for now.

