### PR TITLE
improve(camera/core): live stream

### DIFF
--- a/core/app/templates/alarm/home.html
+++ b/core/app/templates/alarm/home.html
@@ -8,7 +8,7 @@
             <div class="flex justify-between items-center wrap gap-1">
                 <h2 class="h4">{% trans 'Your alarms' %}</h2>
                 <a class="btn-secondary" href="{% url 'alarm:status-add' %}">
-                    {% svg_icon 'plus' 'right' %}
+                    {% svg_icon 'plus' 'left' %}
                     <span>
                         {% trans 'New alarm' %}
                     </span>

--- a/core/app/templates/camera/camera_stream.html
+++ b/core/app/templates/camera/camera_stream.html
@@ -18,7 +18,7 @@
                         <p class="flex items-center">
                             {% svg_icon 'location' %} <span class="l-ml1">{{ camera.device.location }}</span>
                         </p>
-                        <img decoding="async" loading="lazy" src="{% url 'camera:camera_stream' camera.pk %}" alt="{% trans 'Live stream' %}" />
+                        <img src="{% url 'camera:camera_stream' camera.pk %}" alt="{% trans 'Live stream' %}" />
                     </div>
                 </div>
             </div>

--- a/core/app/templates/partials/_alarm_list.html
+++ b/core/app/templates/partials/_alarm_list.html
@@ -20,4 +20,3 @@
         </div>
     {% endfor %}
 </div>
-c

--- a/smart-camera/app/camera/camera_frame_producer.py
+++ b/smart-camera/app/camera/camera_frame_producer.py
@@ -20,6 +20,12 @@ class CameraFrameProducer:
     def publish_to_analyze(self, picture):
         self.mqtt_client.publish(f'{self.TOPIC_PICTURE_TO_ANALYZE}/{self._device_id}', picture, qos=0)
 
+
+    @rate_limited(max_per_second=15, block=False)
+    def publish_stream(self, picture):
+        self.mqtt_client.publish(f'{self.TOPIC_PICTURE_STREAM}/{self._device_id}', picture, qos=0)
+
+
     def start(self) -> None:
         mqtt_client = get_mqtt(client_name=f'{self._device_id}-{CameraFrameProducer.SERVICE_NAME}')
         mqtt_client.connect_keep_status(CameraFrameProducer.SERVICE_NAME, self._device_id)
@@ -35,4 +41,4 @@ class CameraFrameProducer:
             self.publish_to_analyze(picture)
 
         if stream is True:
-            self.mqtt_client.publish(f'{self.TOPIC_PICTURE_STREAM}/{self._device_id}', picture, qos=0)
+            self.publish_stream(picture)


### PR DESCRIPTION
Limit stream at 15 fps and remove image decoding async + lazyloading because it causes flashes on mobile phones (frame then white frame endless).