### PR TITLE
tests(core): add coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,15 +1,24 @@
-#name: Run tests
-#on: [push]
-#jobs:
-#  test:
-#    name: Run django tests
-#    runs-on: ubuntu-20.04
-#    defaults:
-#      run:
-#        working-directory: raspberrypi_central/core
-#    steps:
-#      - uses: actions/checkout@master
-#      - name: test
-#        run: |
-#          bash docker-setup.sh -xe
-#          make test
+name: Run tests
+on: [push]
+jobs:
+  test:
+    name: Run core tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: core
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+ 
+      #- name: Install buildx
+      #  uses: docker/setup-buildx-action@v1.2.0
+      #  id: buildx
+      #  with:
+      #    install: true
+          
+      - name: Run tests & generate coverage report
+        run: |
+            make coverage
+            bash <(curl -s https://codecov.io/bash)
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 .env
 .idea
 .vscode
+htmlcov/
+.coverage
+.coverage.*
+coverage.xml
+*.cover

--- a/core/.env.test
+++ b/core/.env.test
@@ -2,6 +2,7 @@ DEBUG=1
 SECRET_KEY=foo
 DJANGO_ALLOWED_HOSTS=web 192.168.1.37 localhost 127.0.0.1 [::1].
 
+PUBLIC_ASSET=public/assets
 CELERY_BROKER_URL=redis://redis-broker:6379/0
 
 REDIS_HOSTNAME=redis-broker

--- a/core/Makefile
+++ b/core/Makefile
@@ -54,9 +54,13 @@ build-docker:
 docker-build-release:
 	cd app && npm run build && cd - && docker buildx build --build-arg USER_ID=$(user) --build-arg GROUP_ID=$(group) --push --platform linux/arm/v7,linux/amd64 --tag bobbyhome/core:$(version) ./app
 
+.PHONY: coverage
+coverage:
+	$(drtest) web /bin/bash -c 'coverage run manage.py test && coverage xml'
+
 .PHONY: test
 test:
-	$(drtest) web python -Wa manage.py test
+	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 $(drtest) web python -Wa manage.py test
 
 .PHONY: migrations
 migrations:
@@ -65,11 +69,6 @@ migrations:
 .PHONY: migrate
 migrate:
 	$(manage-dev) migrate
-
-.PHONY: tests
-tests:
-	$(manage) test
-
 
 .PHONY: manage
 manage:

--- a/core/app/.coveragerc
+++ b/core/app/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit = *migrations*,*tests*,*apps.py,*manage.py,*admin.py,*urls.py,*factories.py,manage.py,texts.py
+source = .

--- a/core/app/Dockerfile
+++ b/core/app/Dockerfile
@@ -33,8 +33,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 ENV CRYPTOGRAPHY_DONT_BUILD_RUST 1
 
 COPY requirements.txt /tmp/
-RUN --mount=type=cache,mode=0755,target=/root/.cache \
-  pip install --user --requirement /tmp/requirements.txt
+RUN pip install --user --requirement /tmp/requirements.txt
 
 # final image
 FROM base

--- a/core/app/requirements.txt
+++ b/core/app/requirements.txt
@@ -13,3 +13,4 @@ requests==2.25.*
 django_extensions==3.0.9
 Pillow==8.1.*
 freezegun==1.0.0
+coverage==5.5

--- a/core/config/mosquitto/mosquitto-test.conf
+++ b/core/config/mosquitto/mosquitto-test.conf
@@ -1,0 +1,14 @@
+listener 8883
+
+allow_anonymous true
+
+# Types of messages to log. Use multiple log_type lines for logging
+# multiple types of messages.
+# Possible types are: debug, error, warning, notice, information,
+# none, subscribe, unsubscribe, websockets, all.
+# Note that debug type messages are for decoding the incoming/outgoing
+# network packets. They are not logged in "topics".
+log_type all
+
+
+persistence false

--- a/core/docker-compose.override.yml
+++ b/core/docker-compose.override.yml
@@ -21,6 +21,11 @@ services:
         volumes:
             - dev-psql-data:/var/lib/postgresql/data
 
+    mqtt_broker:
+        volumes:
+            - ./config/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
+            - ./config/mosquitto/passwd:/mosquitto/config/passwd
+
     celery_worker:
         <<: *build
         <<: *env
@@ -75,7 +80,13 @@ services:
         - webapp_backend
         - backend_mqtt
 
+networks:
+    backend_mqtt:
+        external: true
+
 volumes:
+    camera_videos:
+        external: true
     dev-redis-broker-data:
         driver: local
     dev-psql-data:

--- a/core/docker-compose.prod.yml
+++ b/core/docker-compose.prod.yml
@@ -29,6 +29,9 @@ services:
     mqtt_broker:
         logging: *loki-logging
         restart: unless-stopped
+        volumes:
+            - ./config/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
+            - ./config/mosquitto/passwd:/mosquitto/config/passwd
 
     loki:
         image: grafana/loki:2.1.0
@@ -92,7 +95,13 @@ services:
         restart: unless-stopped
         <<: *env
 
+networks:
+    backend_mqtt:
+        external: true
+
 volumes:
+    camera_videos:
+        external: true
     grafana-data:
         driver: local
     redis-data:

--- a/core/docker-compose.test.yml
+++ b/core/docker-compose.test.yml
@@ -1,21 +1,48 @@
 version: '3.7'
 
+x-build: &build
+    build:
+        context: ./app
+        args:
+            USER_ID: ${USER_ID}
+            GROUP_ID: ${GROUP_ID}
+
 x-env: &env
     env_file:
         - .env.test
 
 services:
-    rabbit_worker:
+    mqtt_broker:
+        volumes:
+            - ./config/mosquitto/mosquitto-test.conf:/mosquitto/config/mosquitto.conf
+
+    celery_worker:
+        <<: *build
         <<: *env
+        volumes:
+            - ./app/:/usr/src/app/
 
     celery_beat:
+        <<: *build
         <<: *env
+        volumes:
+            - ./app/:/usr/src/app/
 
     web:
+        <<: *build
         <<: *env
+        volumes:
+            - ./app/:/usr/src/app/
 
     python_process_mqtt:
+        <<: *build
         <<: *env
+        volumes:
+            - ./app/:/usr/src/app/
 
     telegram_bot:
+        <<: *build
         <<: *env
+        volumes:
+            - ./app/:/usr/src/app/
+

--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -26,9 +26,7 @@ services:
     mqtt_broker:
         image: eclipse-mosquitto:2.0.10
         volumes:
-            - ./config/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
-            - ./config/mosquitto/passwd:/mosquitto/config/passwd
-            - mosquitto-data:/mosquitto/data
+           - mosquitto-data:/mosquitto/data
         ports:
             - "8883:8883"
         networks:
@@ -104,7 +102,6 @@ networks:
     redis-broker:
     webapp_backend:
     backend_mqtt:
-        external: true
 
 volumes:
     medias:
@@ -116,4 +113,4 @@ volumes:
     vim-plugins:
         driver: local
     camera_videos:
-        external: true
+        driver: local


### PR DESCRIPTION
- [x] Add python `coverage` to generate reports.
- [x] Use Github workflows to run tests
- [x] Use github workflows to generate coverage report and publish it to [codecov.io](codecov.io)

## Issues

### Buildkit not working inside github workflows + docker compose
Before this PR we used buildkit `--mount` feature to cache pip dependencies: cache dependencies of pip is on my device, I mount it to docker so it does not need to download every package every time.

I had to remove this because buildkit does not work well with github workflows. [I know it supports it through an official action](https://github.com/marketplace/actions/docker-setup-buildx) but it does not work. I got this error:

```
[2055] Failed to execute script docker-compose
Traceback (most recent call last):
  File "docker-compose", line 3, in <module>
  File "compose/cli/main.py", line 81, in main
  File "compose/cli/main.py", line 203, in perform_command
  File "compose/metrics/decorator.py", line 18, in wrapper
  File "compose/cli/main.py", line 970, in run
  File "compose/cli/main.py", line 1437, in run_one_off_container
  File "compose/project.py", line 664, in up
  File "compose/service.py", line 364, in ensure_image_exists
  File "compose/service.py", line 1133, in build
  File "compose/service.py", line 1950, in build
IndexError: list index out of range
```

[Example of failed job.](https://github.com/mxmaxime/bobby-home/runs/2456907522?check_suite_focus=true)

I tried to investigate but I did not manage to make it works. So I removed the `--mount`, it's ok because I do not download a lot of heavy libraries but it would be a nice to have... Will investigate when I have time.

I tried to use `--mount` only if buildkit is enabled [using if/else](https://stackoverflow.com/questions/43654656/dockerfile-if-else-condition-with-external-arguments) without success.

Sources:
- https://github.com/docker/compose/issues/7842
- 